### PR TITLE
add async serializer support

### DIFF
--- a/adrf/serializers.py
+++ b/adrf/serializers.py
@@ -1,0 +1,340 @@
+import asyncio
+import traceback
+from collections import OrderedDict
+
+from async_property import async_property
+from django.db import models
+
+from rest_framework.serializers import BaseSerializer as DRFBaseSerializer
+from rest_framework.serializers import ListSerializer as DRFListSerializer
+from rest_framework.serializers import ModelSerializer as DRFModelSerializer
+from rest_framework.serializers import Serializer as DRFSerializer
+from rest_framework.serializers import (
+    SerializerMetaclass as DRFSerializerMetaclass,
+)
+from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
+
+from rest_framework.fields import (  # NOQA # isort:skip
+    Field,
+)
+
+
+from rest_framework.fields import (  # NOQA # isort:skip
+    SkipField,
+)
+
+
+class BaseSerializer(DRFBaseSerializer):
+    """
+    Base serializer class.
+    """
+
+    @classmethod
+    def many_init(cls, *args, **kwargs):
+        allow_empty = kwargs.pop("allow_empty", None)
+        max_length = kwargs.pop("max_length", None)
+        min_length = kwargs.pop("min_length", None)
+        child_serializer = cls(*args, **kwargs)
+        list_kwargs = {"child": child_serializer}
+
+        if allow_empty is not None:
+            list_kwargs["allow_empty"] = allow_empty
+
+        if max_length is not None:
+            list_kwargs["max_length"] = max_length
+
+        if min_length is not None:
+            list_kwargs["min_length"] = min_length
+
+        list_kwargs.update(
+            {
+                key: value
+                for key, value in kwargs.items()
+                if key in LIST_SERIALIZER_KWARGS
+            }
+        )
+
+        meta = getattr(cls, "Meta", None)
+
+        list_serializer_class = getattr(
+            meta, "list_serializer_class", ListSerializer
+        )
+
+        return list_serializer_class(*args, **list_kwargs)
+
+    @async_property
+    async def adata(self):
+        if hasattr(self, "initial_data") and not hasattr(
+            self, "_validated_data"
+        ):
+            msg = (
+                "When a serializer is passed a `data` keyword argument you "
+                "must call `.is_valid()` before attempting to access the "
+                "serialized `.data` representation.\n"
+                "You should either call `.is_valid()` first, "
+                "or access `.initial_data` instead."
+            )
+            raise AssertionError(msg)
+
+        if not hasattr(self, "_data"):
+            if self.instance is not None and not getattr(
+                self, "_errors", None
+            ):
+                self._data = await self.ato_representation(self.instance)
+            elif hasattr(self, "_validated_data") and not getattr(
+                self, "_errors", None
+            ):
+                self._data = await self.ato_representation(self.validated_data)
+            else:
+                self._data = self.get_initial()
+
+        return self._data
+
+    async def ato_representation(self, instance):
+        raise NotImplementedError(
+            "`ato_representation()` must be implemented."
+        )
+
+    async def aupdate(self, instance, validated_data):
+        raise NotImplementedError("`aupdate()` must be implemented.")
+
+    async def acreate(self, validated_data):
+        raise NotImplementedError("`acreate()` must be implemented.")
+
+    async def asave(self, **kwargs):
+        assert hasattr(
+            self, "_errors"
+        ), "You must call `.is_valid()` before calling `.asave()`."
+
+        assert (
+            not self.errors
+        ), "You cannot call `.asave()` on a serializer with invalid data."
+
+        # Guard against incorrect use of `serializer.asave(commit=False)`
+        assert "commit" not in kwargs, (
+            "'commit' is not a valid keyword argument to the 'asave()' method."
+            " If you need to access data before committing to the database"
+            " then inspect 'serializer.validated_data' instead. You can also"
+            " pass additional keyword arguments to 'asave()' if you need to"
+            " set extra attributes on the saved model instance. For example:"
+            " 'serializer.asave(owner=request.user)'.'"
+        )
+
+        assert not hasattr(self, "_data"), (
+            "If you need to access data before committing to the database then"
+            " inspect 'serializer.validated_data' instead. "
+        )
+
+        validated_data = {**self.validated_data, **kwargs}
+
+        if self.instance is not None:
+            self.instance = await self.aupdate(self.instance, validated_data)
+            assert (
+                self.instance is not None
+            ), "`aupdate()` did not return an object instance."
+        else:
+            self.instance = await self.acreate(validated_data)
+            assert (
+                self.instance is not None
+            ), "`acreate()` did not return an object instance."
+
+        return self.instance
+
+
+class _Serializer(metaclass=DRFSerializerMetaclass):
+    pass
+
+
+class Serializer(BaseSerializer, _Serializer, DRFSerializer):
+    @async_property
+    async def adata(self):
+        """
+        Return the serialized data on the serializer.
+        """
+
+        ret = await super().adata
+
+        return ReturnDict(ret, serializer=self)
+
+    async def ato_representation(self, instance):
+        """
+        Object instance -> Dict of primitive datatypes.
+        """
+
+        ret = OrderedDict()
+        fields = self._readable_fields
+
+        drf_fields = DRFModelSerializer.serializer_field_mapping.values()
+
+        for field in fields:
+            try:
+                attribute = field.get_attribute(instance)
+            except SkipField:
+                continue
+
+            is_drf_field = (
+                type(field)
+                in DRFModelSerializer.serializer_field_mapping.values()
+            )
+
+            check_for_none = (
+                attribute.pk
+                if isinstance(attribute, models.Model)
+                else attribute
+            )
+            if check_for_none is None:
+                ret[field.field_name] = None
+            else:
+                # if asyncio.iscoroutinefunction(field.ato_representation):
+                #     repr = await field.ato_representation(attribute)
+                # else:
+                #     repr = field.ato_representation(attribute)
+                # drf fields doesn't have ato_representation they have to_representation. we adjust the above code to work with both
+
+                if is_drf_field:
+                    repr = field.to_representation(attribute)
+                else:
+                    repr = await field.ato_representation(attribute)
+
+                ret[field.field_name] = repr
+
+        return ret
+
+
+class ListSerializer(BaseSerializer, DRFListSerializer):
+    async def ato_representation(self, data):
+        """
+        List of object instances -> List of dicts of primitive datatypes.
+        """
+        # Dealing with nested relationships, data can be a Manager,
+        # so, first get a queryset from the Manager if needed
+
+        iterable = data.all() if isinstance(data, models.Manager) else data
+
+        data = []
+
+        async for item in iterable:
+            data.append(await self.child.ato_representation(item))
+
+        return data
+
+    async def asave(self, **kwargs):
+        """
+        Save and return a list of object instances.
+        """
+        # Guard against incorrect use of `serializer.asave(commit=False)`
+        assert "commit" not in kwargs, (
+            "'commit' is not a valid keyword argument to the 'asave()' method."
+            " If you need to access data before committing to the database"
+            " then inspect 'serializer.validated_data' instead. You can also"
+            " pass additional keyword arguments to 'asave()' if you need to"
+            " set extra attributes on the saved model instance. For example:"
+            " 'serializer.asave(owner=request.user)'.'"
+        )
+
+        validated_data = [{**attrs, **kwargs} for attrs in self.validated_data]
+
+        if self.instance is not None:
+            self.instance = await self.aupdate(self.instance, validated_data)
+            assert (
+                self.instance is not None
+            ), "`aupdate()` did not return an object instance."
+        else:
+            self.instance = await self.acreate(validated_data)
+            assert (
+                self.instance is not None
+            ), "`acreate()` did not return an object instance."
+
+        return self.instance
+
+    async def aupdate(self, instance, validated_data):
+        raise NotImplementedError(
+            "Serializers with many=True do not support multiple update by "
+            "default, only multiple create. For updates it is unclear how to "
+            "deal with insertions and deletions. If you need to support "
+            "multiple update, use a `ListSerializer` class and override "
+            "`.aupdate()` so you can specify the behavior exactly."
+        )
+
+    @async_property
+    async def adata(self):
+        ret = await super().adata
+        return ReturnList(ret, serializer=self)
+
+    async def acreate(self, validated_data):
+        # return [self.child.create(attrs) for attrs in validated_data]
+
+        return [await self.child.acreate(attrs) for attrs in validated_data]
+
+
+class ModelSerializer(Serializer, DRFModelSerializer):
+    async def acreate(self, validated_data):
+        """
+        Create and return a new `Snippet` instance, given the validated data.
+        """
+        raise_errors_on_nested_writes("acreate", self, validated_data)
+
+        ModelClass = self.Meta.model
+
+        info = model_meta.get_field_info(ModelClass)
+        many_to_many = {}
+        for field_name, relation_info in info.relations.items():
+            if relation_info.to_many and (field_name in validated_data):
+                many_to_many[field_name] = validated_data.pop(field_name)
+
+        try:
+            instance = await ModelClass._default_manager.acreate(
+                **validated_data
+            )
+        except TypeError:
+            tb = traceback.format_exc()
+            msg = (
+                "Got a `TypeError` when calling `%s.%s.create()`. "
+                "This may be because you have a writable field on the "
+                "serializer class that is not a valid argument to "
+                "`%s.%s.create()`. You may need to make the field "
+                "read-only, or override the %s.create() method to handle "
+                "this correctly.\nOriginal exception was:\n %s"
+                % (
+                    ModelClass.__name__,
+                    ModelClass._default_manager.name,
+                    ModelClass.__name__,
+                    ModelClass._default_manager.name,
+                    self.__class__.__name__,
+                    tb,
+                )
+            )
+            raise TypeError(msg)
+
+        if many_to_many:
+            for field_name, value in many_to_many.items():
+                field = getattr(instance, field_name)
+                field.set(value)
+
+        return instance
+
+    async def aupdate(self, instance, validated_data):
+        raise_errors_on_nested_writes("aupdate", self, validated_data)
+        info = model_meta.get_field_info(instance)
+
+        # Simply set each attribute on the instance, and then asave it.
+        # Note that unlike `.create()` we don't need to treat many-to-many
+        # relationships as being a special case. During updates we already
+        # have an instance pk for the relationships to be associated with.
+        m2m_fields = []
+        for attr, value in validated_data.items():
+            if attr in info.relations and info.relations[attr].to_many:
+                m2m_fields.append((attr, value))
+            else:
+                setattr(instance, attr, value)
+
+        await instance.asave()
+
+        # Note that many-to-many fields are set after updating instance.
+        # Setting m2m fields triggers signals which could potentially change
+        # updated instance and we do not want it to collide with .update()
+        for attr, value in m2m_fields:
+            field = getattr(instance, attr)
+            field.set(value)
+
+        return instance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,13 @@ readme = "README.md"
 license = "MIT"
 homepage = "https://github.com/em1208/adrf"
 repository = "https://github.com/em1208/adrf"
-include = [
-    "LICENSE",
-]
+include = ["LICENSE"]
 
 [tool.poetry.dependencies]
 python = ">=3.8"
 django = ">=4.1"
 djangorestframework = ">=3.14.0"
+async-property = ">=0.2.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,221 @@
+from collections import ChainMap
+from operator import attrgetter
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.test import TestCase
+
+from adrf.serializers import Serializer
+from rest_framework import serializers
+from rest_framework.test import APIRequestFactory
+
+factory = APIRequestFactory()
+
+
+class MockObject:
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+        self.pk = kwargs.get("pk", None)
+
+        for key, val in kwargs.items():
+            setattr(self, key, val)
+
+    def __str__(self):
+        kwargs_str = ", ".join(
+            [
+                "%s=%s" % (key, value)
+                for key, value in sorted(self._kwargs.items())
+            ]
+        )
+        return "<MockObject %s>" % kwargs_str
+
+
+# replace with django test case
+class TestSerializer(TestCase):
+    def setUp(self):
+        class SimpleSerializer(Serializer):
+            username = serializers.CharField()
+            password = serializers.CharField()
+            age = serializers.IntegerField()
+
+        class CrudSerializer(Serializer):
+            username = serializers.CharField()
+            password = serializers.CharField()
+            age = serializers.IntegerField()
+
+            async def acreate(self, validated_data):
+                return MockObject(**validated_data)
+
+            async def aupdate(self, instance, validated_data):
+                return MockObject(**validated_data)
+
+        self.simple_serializer = SimpleSerializer
+        self.crud_serializer = CrudSerializer
+
+        self.default_data = {
+            "username": "test",
+            "password": "test",
+            "age": 25,
+        }
+        self.default_object = MockObject(**self.default_data)
+
+    async def test_serializer_valid(self):
+        data = {
+            "username": "test",
+            "password": "test",
+            "age": 10,
+        }
+        serializer = self.simple_serializer(data=data)
+        assert serializer.is_valid() is True
+        assert await serializer.adata == data
+        assert serializer.errors == {}
+
+    async def test_serializer_invalid(self):
+        data = {
+            "username": "test",
+            "password": "test",
+        }
+        serializer = self.simple_serializer(data=data)
+
+        assert not serializer.is_valid()
+        assert serializer.validated_data == {}
+        assert await serializer.adata == data
+        assert serializer.errors == {"age": ["This field is required."]}
+
+    async def test_invalid_datatype(self):
+        data = [
+            {
+                "username": "test",
+                "password": "test",
+                "age": 10,
+            }
+        ]
+        serializer = self.simple_serializer(data=data)
+
+        assert not serializer.is_valid()
+        assert serializer.validated_data == {}
+        assert await serializer.adata == {}
+
+        assert serializer.errors == {
+            "non_field_errors": [
+                "Invalid data. Expected a dictionary, but got list."
+            ]
+        }
+
+    async def test_partial_validation(self):
+        data = {
+            "username": "test",
+            "password": "test",
+        }
+        serializer = self.simple_serializer(data=data, partial=True)
+
+        assert serializer.is_valid()
+        assert serializer.validated_data == data
+        assert serializer.errors == {}
+
+    async def test_serialize_chainmap(self):
+        data = {"username": "test"}, {"password": "test"}, {"age": 10}
+
+        serializer = self.simple_serializer(data=ChainMap(*data))
+
+        assert serializer.is_valid()
+        assert serializer.validated_data == {
+            "username": "test",
+            "password": "test",
+            "age": 10,
+        }
+        assert serializer.errors == {}
+
+    # now we test the crud serializer
+    async def test_crud_serializer_create(self):
+        # Create a valid data payload
+        data = self.default_data
+
+        # Create an instance of the serializer
+        serializer = self.crud_serializer(data=data)
+
+        assert serializer.is_valid()
+
+        # Create the object
+        created_object = await serializer.acreate(serializer.validated_data)
+
+        # Verify the object has been created successfully
+        assert isinstance(created_object, MockObject)
+
+        # Verify the object has the correct data
+        assert created_object.username == data["username"]
+        assert created_object.password == data["password"]
+        assert created_object.age == data["age"]
+
+    async def test_crud_serializer_update(self):
+        # Create a valid data payload
+        default_object = self.default_object
+        data = {
+            "username": "test2",
+            "password": "test2",
+            "age": 30,
+        }
+
+        # Update the object using the serializer
+        serializer = self.crud_serializer(default_object, data=data)
+
+        assert serializer.is_valid()
+
+        # Update the object
+        updated_object = await serializer.aupdate(
+            default_object, serializer.validated_data
+        )
+
+        # Verify the object has been updated successfully
+        assert isinstance(updated_object, MockObject)
+        assert updated_object.username == data["username"]
+        assert updated_object.password == data["password"]
+        assert updated_object.age == data["age"]
+
+    # test asave
+    async def test_crud_serializer_save(self):
+        # Create a valid data payload
+        data = self.default_data
+
+        # Create an instance of the serializer
+        serializer = self.crud_serializer(data=data)
+
+        assert serializer.is_valid()
+
+        # Create the object
+        created_object = await serializer.asave()
+
+        # Verify the object has been created successfully
+        assert isinstance(created_object, MockObject)
+
+        # Verify the object has the correct data
+        assert created_object.username == data["username"]
+        assert created_object.password == data["password"]
+        assert created_object.age == data["age"]
+
+    async def test_crud_serializer_to_representation(self):
+        # Create a valid data payload
+        default_object = self.default_object
+
+        # Update the object using the serializer
+        serializer = self.crud_serializer(default_object)
+
+        # Update the object
+        representation = await serializer.ato_representation(default_object)
+
+        # Verify the object has been updated successfully
+        assert isinstance(representation, dict)
+        assert representation["username"] == default_object.username
+        assert representation["password"] == default_object.password
+        assert representation["age"] == default_object.age
+
+    # test that normal non-async serializers work
+    def test_async_serializer_valid(self):
+        data = {
+            "username": "test",
+            "password": "test",
+            "age": 10,
+        }
+        serializer = self.simple_serializer(data=data)
+        assert serializer.is_valid() is True
+        assert serializer.data == data
+        assert serializer.errors == {}


### PR DESCRIPTION
This is a draft to add essential support for async serializers. Like Django's async support, I have added "a" as a prefix to methods that needs to be async. e.g. "save", "create", "update" and "ato_representation". The typical non-async methods still work as usual.