### PR TITLE
Fix to_representation when using ChoiceField.

### DIFF
--- a/adrf/serializers.py
+++ b/adrf/serializers.py
@@ -153,10 +153,9 @@ class Serializer(BaseSerializer, _Serializer, DRFSerializer):
             except SkipField:
                 continue
 
-            is_drf_field = (
-                type(field)
-                in DRFModelSerializer.serializer_field_mapping.values()
-            )
+            is_drf_field = type(field) in list(
+                DRFModelSerializer.serializer_field_mapping.values()
+            ) + [DRFModelSerializer.serializer_choice_field]
 
             check_for_none = (
                 attribute.pk


### PR DESCRIPTION
When serializing, execution fails in `to_representation` with `AttributeError: 'ChoiceField' object has no attribute 'ato_representation'`.

Ful stack trace:
```
  File "/usr/local/lib/python3.11/site-packages/adrf/views.py", line 61, in async_dispatch
    response = await handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/custom/functions.py", line 32, in get_data
    result = await client.make_call(data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/custom/client.py", line 339, in make_call
    validated_data = await serializer.adata
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/async_property/base.py", line 37, in get_value
    return await self._fget(instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/adrf/serializers.py", line 157, in adata
    ret = await super().adata
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/async_property/base.py", line 37, in get_value
    return await self._fget(instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/adrf/serializers.py", line 89, in adata
    self._data = await self.ato_representation(self.validated_data)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/adrf/serializers.py", line 198, in ato_representation
    repr = await field.ato_representation(attribute)
                 ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ChoiceField' object has no attribute 'ato_representation'
```

The issue lies in the decision of whether the field is a DRF field or not. `DRFModelSerializer.serializer_field_mapping` does not include `ChoiceField`, it is instead defined separately in `serializer_choice_field`.
```
            is_drf_field = (
                type(field)
                in DRFModelSerializer.serializer_field_mapping.values()
            )
```