### PR TITLE
fix: AsyncAPIClient was not forcing authentication

### DIFF
--- a/adrf/test.py
+++ b/adrf/test.py
@@ -25,6 +25,12 @@ class AsyncForceAuthClientHandler(AsyncClientHandler):
         force_authenticate(request, self._force_user, self._force_token)
         return super().get_response(request)
 
+    async def get_response_async(self, request):
+        # This is the simplest place we can hook into to patch the
+        # request object.
+        force_authenticate(request, self._force_user, self._force_token)
+        return await super().get_response_async(request)
+
 
 class AsyncAPIRequestFactory(DjangoAsyncRequestFactory):
     renderer_classes_list = api_settings.TEST_REQUEST_RENDERER_CLASSES


### PR DESCRIPTION
Django uses `get_response_async` when running in an async context. Without overriding it, `force_authentiction` was not working on async tests.

As a next step, we should refactor some tests to use AsyncClients instead of DRF's sync ones.