### PR TITLE
Update README description on ViewSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,25 @@ urlpatterns = [
 
 ```
 
+## ModelViewSet Routing
+
+The `ModelViewSet` implementation included with adrf provides asynchronous CRUD actions (e.g., `aretrieve`, `acreate`, `aupdate`, and `alist`). However, these actions are not invoked by default when using the router implementation in `rest_framework`. To have these async methods mapped by default, use adrf's router instead:
+
+```python
+from django.urls import path, include
+from adrf import routers    # import the adrf router instead
+
+from . import views
+
+router = routers.DefaultRouter()
+router.register(r"async_viewset", views.AsyncModelViewSet, basename="async")
+
+urlpatterns = [
+    path("", include(router.urls)),
+]
+
+```
+
 # Async Serializers
 
 serializers.py


### PR DESCRIPTION
The example in the README for usage of ViewSets shows a simple ViewSet registered with `rest_framework`'s built-in router implementation. However, if you use the `rest_framework` router with the `ModelViewSet` provided by `adrf`, the async versions of the standard ViewSet actions are not invoked. I propose adding a small section to the README to highlight this distinction to avoid some potential confusion, as personally this nuance threw me off a bit when using this library for the first time.

Resolves #63.