### PR TITLE
Issue/55

### DIFF
--- a/adrf/mixins.py
+++ b/adrf/mixins.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 async def get_data(serializer):
     """Use adata if the serializer supports it, data otherwise."""
-    return await serializer.adata if hasattr(serializer, "adata") else serializer.data
+    return await serializer.adata if hasattr(serializer, "adata") else await sync_to_async(lambda: serializer.data)()
 
 
 class CreateModelMixin(mixins.CreateModelMixin):

--- a/adrf/serializers.py
+++ b/adrf/serializers.py
@@ -2,9 +2,9 @@ import asyncio
 import traceback
 from collections import OrderedDict
 
+from asgiref.sync import sync_to_async
 from async_property import async_property
 from django.db import models
-from asgiref.sync import sync_to_async
 from rest_framework.fields import SkipField
 from rest_framework.serializers import (
     LIST_SERIALIZER_KWARGS,

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -291,3 +291,41 @@ class TestSerializerWithSerializerMethodField(TestCase):
         assert serializer.is_valid()
         assert await serializer.adata == data_with_age
         assert serializer.errors == {}
+
+
+class TestModelDepthSerializer(TestCase):
+    def setUp(self) -> None:
+        class UserSerializer(ModelSerializer):
+            class Meta:
+                model = User
+                fields = "__all__"
+
+        class OrderSerializer(ModelSerializer):
+            class Meta:
+                model = Order
+                fields = ("id", "user", "name")
+                depth = 1
+
+        self.user_serializer = UserSerializer
+        self.order_serializer = OrderSerializer
+
+    async def test_order_serializer_for_depth_gt_0(self):
+        user = await User.objects.acreate(username="test")
+        # get an order with the fk user
+        order = await Order.objects.acreate(user=user, name="Test order")
+        # serializing the user is the most reproducible way to get its dict
+        # for testing
+        user_serializer = self.user_serializer(user)
+        data = {
+            "user": await user_serializer.adata,
+            "name": "Test order",
+            "id": 1,
+        }
+        # get the order serializer
+        order_serializer = self.order_serializer(order)
+        # calling `.adata` here will not include the nested user structure
+        # without the above `depth = 1` specification on the `Meta` object
+        # Additionally: this code raises `SynchronousOnlyOperation` when
+        # `sync_to_async` guards are not correctly in place in the callstack
+        assert await order_serializer.adata == data
+        assert (await order_serializer.adata)["user"] == await user_serializer.adata


### PR DESCRIPTION
# Fixing `SynchronousOnlyOperation` raising for some ORM operations

Resolving issues https://github.com/em1208/adrf/issues/55 and https://github.com/em1208/adrf/issues/56

There are possibly some other cases where these still raise? These were the ones I ran into and then found issues for opened by @chafikblm.

I've added a Serializer test case based on the pre-existing Serializer test case to specifically test for the depth > 0 behaviour being handled correctly - it fails without the fixes / passes with them - but may need some adjustments to bring it inline with standards. In theory, this is sufficient to test for the resolution of the issues, but it is just the one case I found that raises the issues in the callstack - there may be other ways of raising the issue that don't run through this exact path that the fix addresses. Notably, https://github.com/GregSym/adrf/blob/d0e6aee0c45914908c5c4acfa1e47de52d549495/adrf/serializers.py#L146 is critical to fixing the issue in my actual codebase (which involves some additional features, like compound PKs and FKs, that may be out of scope here) but is not tested for here