### PR TITLE
Wrap object permissions check in `sync_to_async`

### DIFF
--- a/adrf/generics.py
+++ b/adrf/generics.py
@@ -47,7 +47,7 @@ class GenericAPIView(views.APIView, DRFGenericAPIView):
         obj = await aget_object_or_404(queryset, **filter_kwargs)
 
         # May raise a permission denied
-        self.check_object_permissions(self.request, obj)
+        await sync_to_async(self.check_object_permissions)(self.request, obj)
 
         return obj
 


### PR DESCRIPTION
This pull request wraps the `check_object_permissions` call used in `aget_object` in `sync_to_async`. This is to help avoid `SynchronousOnlyOperation` or `RuntimeError` exceptions when more in-depth permissions checks are used.

Resolves #74.