### PR TITLE
issue-75-django-validationerror

### DIFF
--- a/adrf/generics.py
+++ b/adrf/generics.py
@@ -1,9 +1,8 @@
 import asyncio
 
 from asgiref.sync import async_to_sync, sync_to_async
-from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.exceptions import ValidationError
 from django.http import Http404
-from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.generics import GenericAPIView as DRFGenericAPIView
 
 from adrf import mixins, views
@@ -17,7 +16,7 @@ async def aget_object_or_404(queryset, *filter_args, **filter_kwargs):
     """
     try:
         return await _aget_object_or_404(queryset, *filter_args, **filter_kwargs)
-    except (TypeError, ValueError, DjangoValidationError, DRFValidationError):
+    except (TypeError, ValueError, ValidationError):
         raise Http404
 
 

--- a/adrf/generics.py
+++ b/adrf/generics.py
@@ -1,8 +1,9 @@
 import asyncio
 
 from asgiref.sync import async_to_sync, sync_to_async
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import Http404
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.generics import GenericAPIView as DRFGenericAPIView
 
 from adrf import mixins, views
@@ -16,7 +17,7 @@ async def aget_object_or_404(queryset, *filter_args, **filter_kwargs):
     """
     try:
         return await _aget_object_or_404(queryset, *filter_args, **filter_kwargs)
-    except (TypeError, ValueError, ValidationError):
+    except (TypeError, ValueError, DjangoValidationError, DRFValidationError):
         raise Http404
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.contrib.auth.models import User
 from django.db import models
 
@@ -13,3 +15,8 @@ class ModelA(models.Model):
 
 class ModelB(models.Model):
     fielda = models.ForeignKey(ModelA, on_delete=models.CASCADE)
+
+
+class UUIDModel(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.TextField()

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -5,7 +5,7 @@ from rest_framework.test import APIRequestFactory
 
 from adrf import generics, serializers
 
-from .models import Order, User
+from .models import Order, User, UUIDModel
 
 factory = APIRequestFactory()
 
@@ -29,6 +29,17 @@ class ListUserView(generics.ListAPIView):
 class RetrieveUserView(generics.RetrieveAPIView):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+
+
+class UUIDModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = UUIDModel
+        fields = ("id", "name")
+
+
+class RetrieveUUIDModelView(generics.RetrieveAPIView):
+    queryset = UUIDModel.objects.all()
+    serializer_class = UUIDModelSerializer
 
 
 class DestroyUserView(generics.DestroyAPIView):
@@ -89,6 +100,16 @@ class TestRetrieveUserView(TestCase):
         expected = {"username": "test"}
         assert response.status_code == status.HTTP_200_OK
         assert response.data == expected
+
+
+class TestRetrieveUUIDModelView(TestCase):
+    def setUp(self):
+        self.view = RetrieveUUIDModelView.as_view()
+
+    def test_get_invalid_uuid_returns_404(self):
+        request = factory.get("/")
+        response = async_to_sync(self.view)(request, pk="not-a-uuid")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 class TestDestroyUserView(TestCase):


### PR DESCRIPTION
This pull request ensures that `aget_object_or_404` only catches and handles `ValidationError` from Django, matching DRF. fixes https://github.com/em1208/adrf/issues/75